### PR TITLE
OHRM5X-1072: timesheet comment required validation removed from BE

### DIFF
--- a/symfony/plugins/orangehrmTimePlugin/Api/TimesheetCommentAPI.php
+++ b/symfony/plugins/orangehrmTimePlugin/Api/TimesheetCommentAPI.php
@@ -160,7 +160,7 @@ class TimesheetCommentAPI extends Endpoint implements ResourceEndpoint
                     new Rule(Rules::POSITIVE),
                 ),
             ),
-            $this->getValidationDecorator()->requiredParamRule(
+            $this->getValidationDecorator()->notRequiredParamRule(
                 new ParamRule(
                     self::PARAMETER_COMMENT,
                     new Rule(Rules::STRING_TYPE),


### PR DESCRIPTION
This PR Contains following fixes:
1. Time sheet Comment BE Validation removed.